### PR TITLE
Feature/resolver mappings

### DIFF
--- a/src/bitExpert/Adroit/Resolver/AbstractMappingResolver.php
+++ b/src/bitExpert/Adroit/Resolver/AbstractMappingResolver.php
@@ -45,7 +45,7 @@ abstract class AbstractMappingResolver implements Resolver
      */
     public function resolve($identifier)
     {
-        $mappedIdentifier = $this->getMapping($identifier);
+        $mappedIdentifier = $this->map($identifier);
 
         if (!$mappedIdentifier) {
             $this->logger->warning(sprintf(
@@ -59,12 +59,12 @@ abstract class AbstractMappingResolver implements Resolver
     }
 
     /**
-     * Resolves the original identifier to the mapped one
+     * Maps the original identifier to the mapped one
      *
      * @param $identifier
      * @return mixed|null
      */
-    protected function getMapping($identifier)
+    protected function map($identifier)
     {
         if (!isset($this->mappings[$identifier])) {
             return null;

--- a/src/bitExpert/Adroit/Resolver/AbstractMappingResolver.php
+++ b/src/bitExpert/Adroit/Resolver/AbstractMappingResolver.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the Adroit package.
+ *
+ * (c) bitExpert AG
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace bitExpert\Adroit\Resolver;
+
+use bitExpert\Slf4PsrLog\LoggerFactory;
+
+/**
+ * Class AbstractMappingResolver
+ * A Resolver which maps the original identifier to another one before resolving
+ *
+ * @package bitExpert\Adroit\Resolver
+ */
+abstract class AbstractMappingResolver implements Resolver
+{
+    /**
+     * @var array
+     */
+    protected $mappings;
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
+
+    /**
+     * MappingResolver constructor.
+     * @param array $mappings
+     */
+    public function __construct(array $mappings)
+    {
+        $this->logger = LoggerFactory::getLogger(__CLASS__);
+        $this->mappings = $mappings;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve($identifier)
+    {
+        $mappedIdentifier = $this->getMapping($identifier);
+
+        if (!$mappedIdentifier) {
+            $this->logger->warning(sprintf(
+                'Could not find mapping for identifier "%s"',
+                $identifier
+            ));
+            return null;
+        }
+
+        return $this->resolveMapped($mappedIdentifier);
+    }
+
+    /**
+     * Resolves the original identifier to the mapped one
+     *
+     * @param $identifier
+     * @return mixed|null
+     */
+    protected function getMapping($identifier)
+    {
+        if (!isset($this->mappings[$identifier])) {
+            return null;
+        }
+
+        return $this->mappings[$identifier];
+    }
+
+    /**
+     * Resolves the mapped identifier
+     *
+     * @param $mappedIdentifier
+     * @return mixed
+     */
+    abstract protected function resolveMapped($mappedIdentifier);
+}

--- a/src/bitExpert/Adroit/Resolver/ContainerResolver.php
+++ b/src/bitExpert/Adroit/Resolver/ContainerResolver.php
@@ -17,7 +17,7 @@ use Interop\Container\ContainerInterface;
  * Implementation of an {@link \bitExpert\Adroit\Resolver\Resolver} which will
  * pull the results from a "container-aware" service.
  */
-class ContainerResolver implements Resolver
+class ContainerResolver extends AbstractMappingResolver
 {
     /**
      * @var ContainerInterface
@@ -32,12 +32,27 @@ class ContainerResolver implements Resolver
      * Creates a new {@link \bitExpert\Adroit\Action\Resolver\ContainerAwareActionResolver}.
      *
      * @param ContainerInterface $container
+     * @param array $mappings
      * @throws \RuntimeException
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(ContainerInterface $container, array $mappings = [])
     {
+        parent::__construct($mappings);
+        
         $this->container = $container;
         $this->logger = LoggerFactory::getLogger(__CLASS__);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function map($identifier)
+    {
+        if (!count($this->mappings)) {
+            return $identifier;
+        }
+
+        return parent::map($identifier);
     }
 
     /**
@@ -45,7 +60,7 @@ class ContainerResolver implements Resolver
      * @throws \Interop\Container\Exception\ContainerException
      * @throws \Interop\Container\Exception\NotFoundException
      */
-    public function resolve($identifier)
+    public function resolveMapped($identifier)
     {
         if (!$this->container->has($identifier)) {
             $this->logger->error(

--- a/src/bitExpert/Adroit/Resolver/ContainerResolver.php
+++ b/src/bitExpert/Adroit/Resolver/ContainerResolver.php
@@ -62,6 +62,10 @@ class ContainerResolver extends AbstractMappingResolver
      */
     public function resolveMapped($identifier)
     {
+        if (!is_string($identifier)) {
+            return null;
+        }
+
         if (!$this->container->has($identifier)) {
             $this->logger->error(
                 sprintf(

--- a/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
+++ b/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
@@ -153,4 +153,23 @@ class ContainerResolverUnitTest extends \PHPUnit_Framework_TestCase
         $resolved = $resolver->resolve($identifier);
         $this->assertSame($obj, $resolved);
     }
+
+    /**
+     * @test
+     */
+    public function willDirectlyReturnNullIfIdentifierIsNotAString()
+    {
+        $identifier = 1;
+
+        $resolver = new ContainerResolver($this->container);
+
+        $this->container->expects($this->never())
+            ->method('has');
+
+        $this->container->expects($this->never())
+            ->method('get');
+
+        $resolved = $resolver->resolve($identifier);
+        $this->assertNull($resolved);
+    }
 }

--- a/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
+++ b/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
@@ -129,4 +129,28 @@ class ContainerResolverUnitTest extends \PHPUnit_Framework_TestCase
         $resolved = $resolver->resolve($identifier);
         $this->assertNull($resolved);
     }
+
+    /**
+     * @test
+     */
+    public function directlyUsesIdentifierIfMappingsNotProvided()
+    {
+        $identifier = 'test';
+        $obj = new \stdClass();
+
+        $resolver = new ContainerResolver($this->container);
+
+        $this->container->expects($this->once())
+            ->method('has')
+            ->with($identifier)
+            ->will($this->returnValue(true));
+
+        $this->container->expects($this->once())
+            ->method('get')
+            ->with($identifier)
+            ->will($this->returnValue($obj));
+
+        $resolved = $resolver->resolve($identifier);
+        $this->assertSame($obj, $resolved);
+    }
 }

--- a/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
+++ b/tests/bitExpert/Adroit/Resolver/ContainerResolverUnitTest.php
@@ -78,20 +78,55 @@ class ContainerResolverUnitTest extends \PHPUnit_Framework_TestCase
      */
     public function returnsNullIfIdIsNull()
     {
-        $id = null;
+        $resolved = $this->resolver->resolve(null);
+        $this->assertNull($resolved);
+    }
+
+    /**
+     * @test
+     */
+    public function correctlyMapsIdentifiers()
+    {
+        $identifier = 'test';
+        $mappedIdentifier = 'mappedTest';
         $obj = new \stdClass();
+
+        $resolver = new ContainerResolver($this->container, [
+            $identifier => $mappedIdentifier
+        ]);
 
         $this->container->expects($this->once())
             ->method('has')
-            ->with($id)
+            ->with($mappedIdentifier)
             ->will($this->returnValue(true));
 
         $this->container->expects($this->once())
             ->method('get')
-            ->with($id)
+            ->with($mappedIdentifier)
             ->will($this->returnValue($obj));
 
-        $resolved = $this->resolver->resolve($id);
+        $resolved = $resolver->resolve($identifier);
         $this->assertSame($obj, $resolved);
+    }
+
+    /**
+     * @test
+     */
+    public function directlyReturnsNullIfMappingIsNotFound()
+    {
+        $identifier = 'test1';
+
+        $resolver = new ContainerResolver($this->container, [
+            'test' => 'mappedTest'
+        ]);
+
+        $this->container->expects($this->never())
+            ->method('has');
+
+        $this->container->expects($this->never())
+            ->method('get');
+
+        $resolved = $resolver->resolve($identifier);
+        $this->assertNull($resolved);
     }
 }


### PR DESCRIPTION
When using the ContainerResolver, the Resolver will use the type of the domain payload to resolve the responder. 

Since the payload type only should describe the type of the payload while the resolver should look for the responder according to given payload type a 1:1 resolution may not be appropriate in this case, since you either would use

``` php
new DomainPayload('userResponder')
```

to use the userResponder object of the container which would imply that you possibly had to delegate that object to a generic responder or you would use

``` php
new DomainPayload('user')
```

which would force you to make an object accessible with the identifier 'user' which may be very confusing.

This PR includes the possibility to map the identifier BEFORE resolving it from the container:

``` php
new ContainerResolver($container, [
    'user' => 'jsonResponder'
]);
```

so the resolver would lookup 'jsonResponder' in the container, when receiving a domainpayload of type 'user'.

If someone doesn't set a high value on such semantics, he still may use the ContainerResolver without mappings since the mappings param is optional and will be completely ignored if not provided.
